### PR TITLE
Improved Text Extraction & Chunking (& More)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,3 @@
 venv/
 chroma_db/
+*.ipynb

--- a/backend/README.md
+++ b/backend/README.md
@@ -47,9 +47,12 @@ requests server-side, not from a browser origin.
 
 ## Testing Locally
 ```python
-VECTOR_DB=chroma python main.py 
+VECTOR_DB=chroma LOAD_MODELS=true LLM_MODEL=HuggingFaceTB/SmolLM2-360M-Instruct EMBEDDER_MODEL=sentence-transformers/all-MiniLM-L6-v2 python3 main.py
 ```
 * Will use ChromaDB instead of PGVector
+* If LOAD_MODELS=true, will use the specified models. The ones specified here are much weaker than the production one and can be run from CPU
+    * Weaker models are also dumber, so do not expect responses directly related to documents; just a way to test interaction
+* If LOAD_MODELS=false, will use a MockLLM, that is, no LLM at all. Will just return the chunks as a formatted response.
 
 ## PG Vector
 To check if DB contains right data; use the following commands:

--- a/backend/chunker.py
+++ b/backend/chunker.py
@@ -1,8 +1,8 @@
 """
 Section-aware chunker for research-paper PDFs.
 
-Consumes the output of ``extractor.extract_sections`` — a list of
-:class:`~extractor.Section` objects — and produces LangChain ``Document``
+Consumes the output of ``text_extractor.extract_sections`` — a list of
+:class:`~text_extractor.Section` objects — and produces LangChain ``Document``
 objects ready for embedding and retrieval.
 
 All size limits (``chunk_size``, ``chunk_overlap``, ``min_section_tokens``)

--- a/backend/chunker.py
+++ b/backend/chunker.py
@@ -134,7 +134,7 @@ def chunk_pages(
                         page_content=chunk_text,
                         metadata={
                             "document_id": document_id,
-                            "page": page_number,
+                            "page_index": page_number,
                             "section": section_title,
                             "section_index": section_index,
                             "local_chunk_index": local_chunk_index,

--- a/backend/chunker.py
+++ b/backend/chunker.py
@@ -1,158 +1,356 @@
-import re
-from typing import Iterable
+"""
+Section-aware chunker for research-paper PDFs.
 
+Consumes the output of ``extractor.extract_sections`` — a list of
+:class:`~extractor.Section` objects — and produces LangChain ``Document``
+objects ready for embedding and retrieval.
+
+All size limits (``chunk_size``, ``chunk_overlap``, ``min_section_tokens``)
+are expressed in **tokens**, counted via ``tiktoken``.  This makes the limits
+directly meaningful for any downstream model or embedding API regardless of
+the character-to-token ratio of the text.
+
+Chunking strategy per section
+------------------------------
+1. **Fits** (tokens <= chunk_size): emit as a single Document.
+2. **Oversized**: split into paragraphs → greedily merge up to *chunk_size*
+   tokens with paragraph-level overlap → ``RecursiveCharacterTextSplitter``
+   (tiktoken-based) as a last-resort fallback for any individually oversized
+   paragraph (e.g. a long table or unbroken figure caption).
+
+Additionally, **undersized sections are merged** with their successor before
+chunking when both are below *min_section_tokens*.
+
+Output metadata
+---------------
+    chunk_id            str   "{document_id}_chunk_{n}"
+    chunk_index         int   global position in the final list
+    document_id         str
+    section             str | None
+    section_level       int   1 = #, 2 = ##, …
+    section_index       int   position of the section (after any merging)
+    local_chunk_index   int   position of this chunk within its section
+    page_start          int   first page the chunk's text occupies
+    page_end            int   last page the chunk's text occupies (inclusive)
+    page                int   single best page for citation: equal to
+                              page_start when the chunk lives on one page,
+                              otherwise the page contributing the most
+                              characters (dominant page)
+    num_images          int   always 0 (images not carried through Markdown path)
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+
+import tiktoken
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 
-SECTION_HEADING_PATTERN = re.compile(
-    r"^\s*(?:"
-    r"(?:\d+(?:\.\d+)*\.?\s+[A-Z][^\n]{2,120})"
-    r"|(?:Abstract|Introduction|Background|Related Work|Method|Methods|Methodology|"
-    r"Experiments|Results|Discussion|Conclusion|References|Appendix)\s*$"
-    r")",
-    re.IGNORECASE,
-)
+# ---------------------------------------------------------------------------
+# Token counting
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=4)
+def _get_encoding(model: str) -> tiktoken.Encoding:
+    """Return (and cache) the tiktoken encoding for *model*."""
+    try:
+        return tiktoken.encoding_for_model(model)
+    except KeyError:
+        # Fall back to the broadly-compatible cl100k_base encoding.
+        return tiktoken.get_encoding("cl100k_base")
 
 
-def _clean_text(text: str) -> str:
-    text = text or ""
-    text = re.sub(r"-\n(?=\w)", "", text)
-    text = re.sub(r"[ \t]+", " ", text)
-    text = re.sub(r"\n{3,}", "\n\n", text)
-    return text.strip()
+def _count_tokens(text: str, encoding: tiktoken.Encoding) -> int:
+    return len(encoding.encode(text))
 
 
-def _is_section_heading(line: str) -> bool:
-    line = line.strip()
-    if not line:
-        return False
-    return bool(SECTION_HEADING_PATTERN.match(line))
+def _pages_for_range(
+    page_spans: list[tuple[int, int, int]], start: int, end: int
+) -> tuple[int | None, int | None]:
+    """Return (min_page, max_page) of pages overlapping ``[start, end)``."""
+    pages: set[int] = set()
+    for s, e, p in page_spans:
+        if e <= start or s >= end:
+            continue
+        pages.add(p)
+    if not pages:
+        return None, None
+    return min(pages), max(pages)
 
 
-def _split_page_into_sections(text: str) -> list[tuple[str | None, str]]:
-    lines = text.splitlines()
-    sections: list[tuple[str | None, list[str]]] = []
-    current_heading: str | None = None
-    current_lines: list[str] = []
+def _dominant_page(
+    page_spans: list[tuple[int, int, int]], start: int, end: int
+) -> int | None:
+    """Return the page contributing the most characters to ``[start, end)``.
 
-    for line in lines:
-        stripped = line.strip()
+    Ties are broken by the lower page number (earlier in the document).
+    """
+    counts: dict[int, int] = {}
+    for s, e, p in page_spans:
+        overlap = max(0, min(e, end) - max(s, start))
+        if overlap:
+            counts[p] = counts.get(p, 0) + overlap
+    if not counts:
+        return None
+    return max(counts.items(), key=lambda kv: (kv[1], -kv[0]))[0]
 
-        if _is_section_heading(stripped):
-            if current_lines:
-                sections.append((current_heading, current_lines))
-            current_heading = stripped
-            current_lines = [stripped]
-        else:
-            current_lines.append(line)
 
-    if current_lines:
-        sections.append((current_heading, current_lines))
-
-    return [
-        (heading, "\n".join(section_lines).strip())
-        for heading, section_lines in sections
-        if "\n".join(section_lines).strip()
-    ]
-
+# ---------------------------------------------------------------------------
+# Paragraph splitting and token-aware merging
+# ---------------------------------------------------------------------------
 
 def _split_paragraphs(text: str) -> list[str]:
-    paragraphs = re.split(r"\n\s*\n", text)
-    return [p.strip() for p in paragraphs if p.strip()]
+    """Split *text* on blank lines, returning non-empty paragraph strings."""
+    return [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
 
 
 def _merge_paragraphs(
-    paragraphs: Iterable[str],
-    max_chars: int,
-    overlap_chars: int,
+    paragraphs: list[str],
+    max_tokens: int,
+    overlap_tokens: int,
+    encoding: tiktoken.Encoding,
 ) -> list[str]:
+    """
+    Greedily merge *paragraphs* into chunks of at most *max_tokens*.
+
+    Token counts are computed once per paragraph and cached in a local list to
+    avoid re-encoding on every iteration.
+
+    Overlap is seeded from the last *whole paragraph* that was flushed,
+    provided its token count fits within *overlap_tokens*.  This keeps overlap
+    coherent at paragraph boundaries rather than slicing mid-token.
+    """
+    # Pre-compute token counts; +2 tokens budgeted for the "\n\n" separator.
+    sep_tokens = _count_tokens("\n\n", encoding)
+    para_tokens = [_count_tokens(p, encoding) for p in paragraphs]
+
     chunks: list[str] = []
-    current = ""
+    current_parts: list[str] = []
+    current_tokens: int = 0
 
-    for paragraph in paragraphs:
-        if not current:
-            current = paragraph
-            continue
+    def _join(parts: list[str]) -> str:
+        return "\n\n".join(parts)
 
-        candidate = current + "\n\n" + paragraph
+    for para, tokens in zip(paragraphs, para_tokens):
+        added = tokens + (sep_tokens if current_parts else 0)
 
-        if len(candidate) <= max_chars:
-            current = candidate
-        else:
-            chunks.append(current)
+        if current_parts and current_tokens + added > max_tokens:
+            chunks.append(_join(current_parts))
+            last_para = current_parts[-1]
+            last_tokens = para_tokens[paragraphs.index(last_para)]
 
-            if overlap_chars > 0:
-                overlap = current[-overlap_chars:]
-                current = overlap + "\n\n" + paragraph
+            if overlap_tokens > 0 and last_para != para and last_tokens <= overlap_tokens:
+                current_parts = [last_para, para]
+                current_tokens = last_tokens + sep_tokens + tokens
             else:
-                current = paragraph
+                current_parts = [para]
+                current_tokens = tokens
+        else:
+            current_parts.append(para)
+            current_tokens += added
 
-    if current:
-        chunks.append(current)
+    if current_parts:
+        chunks.append(_join(current_parts))
 
     return chunks
 
 
-def chunk_pages(
-    pages,
-    document_id: str,
-    chunk_size: int = 1200,
-    chunk_overlap: int = 150,
-) -> list[Document]:
-    """
-    Chunk extracted research-paper pages into LangChain Documents.
+# ---------------------------------------------------------------------------
+# Section merging
+# ---------------------------------------------------------------------------
 
-    Strategy:
-    1. Preserve document/page metadata.
-    2. Detect likely research-paper section headings.
-    3. Split pages into section-aware blocks.
-    4. Split sections into paragraphs.
-    5. Merge paragraphs into chunks.
-    6. Use RecursiveCharacterTextSplitter only as fallback for oversized chunks.
+def _merge_small_sections(sections, min_tokens: int, encoding: tiktoken.Encoding):
     """
-    initial_chunks: list[Document] = []
+    Merge consecutive sections that are individually below *min_tokens*.
 
-    for page_number, page in enumerate(pages, start=1):
-        page_text = _clean_text(getattr(page, "texts", "") or "")
-        if not page_text:
+    A short section is absorbed into its successor until the combined token
+    count crosses *min_tokens* or there are no more sections to absorb.  The
+    merged section keeps the title and level of the first section in the group.
+    """
+    if not sections:
+        return sections
+
+    from text_extractor import Section  # local import to avoid circular dependency
+
+    merged: list[Section] = []
+    buffer: Section | None = None
+    buffer_tokens: int = 0
+
+    for section in sections:
+        section_tokens = _count_tokens(section.text, encoding)
+
+        if buffer is None:
+            buffer = section
+            buffer_tokens = section_tokens
             continue
 
-        sections = _split_page_into_sections(page_text)
-
-        for section_index, (section_title, section_text) in enumerate(sections):
-            paragraphs = _split_paragraphs(section_text)
-            merged_chunks = _merge_paragraphs(
-                paragraphs=paragraphs,
-                max_chars=chunk_size,
-                overlap_chars=chunk_overlap,
+        if buffer_tokens < min_tokens and buffer_tokens + section_tokens <= min_tokens * 4:
+            from text_extractor import Section as _Section
+            sep = "\n\n"
+            new_text = buffer.text + sep + section.text
+            shift = len(buffer.text) + len(sep)
+            new_spans = list(buffer.page_spans) + [
+                (s + shift, e + shift, p) for (s, e, p) in section.page_spans
+            ]
+            buffer = _Section(
+                title=buffer.title,
+                level=buffer.level,
+                text=new_text,
+                page_start=buffer.page_start,
+                page_end=section.page_end,
+                page_spans=new_spans,
             )
+            buffer_tokens = _count_tokens(buffer.text, encoding)
+        else:
+            merged.append(buffer)
+            buffer = section
+            buffer_tokens = section_tokens
 
-            for local_chunk_index, chunk_text in enumerate(merged_chunks):
-                initial_chunks.append(
-                    Document(
-                        page_content=chunk_text,
-                        metadata={
-                            "document_id": document_id,
-                            "page_index": page_number,
-                            "section": section_title,
-                            "section_index": section_index,
-                            "local_chunk_index": local_chunk_index,
-                            "num_images": len(getattr(page, "images", [])),
-                        },
-                    )
-                )
+    if buffer is not None:
+        merged.append(buffer)
 
-    fallback_splitter = RecursiveCharacterTextSplitter(
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def chunk_sections(
+    sections,
+    document_id: str,
+    chunk_size: int = 512,
+    chunk_overlap: int = 64,
+    min_section_tokens: int = 64,
+    tiktoken_model: str = "text-embedding-3-small",
+) -> list[Document]:
+    """
+    Chunk a list of :class:`~extractor.Section` objects into LangChain
+    ``Document`` objects suitable for embedding and retrieval.
+
+    Parameters
+    ----------
+    sections:
+        Output of ``extractor.extract_sections``.
+    document_id:
+        Stable identifier for the source document (used in ``chunk_id``).
+    chunk_size:
+        Maximum tokens per chunk.
+    chunk_overlap:
+        Maximum tokens of overlap between consecutive chunks from the same
+        section (implemented at paragraph granularity).
+    min_section_tokens:
+        Sections shorter than this are merged with their successor before
+        chunking.  Set to 0 to disable merging.
+    tiktoken_model:
+        Model name passed to ``tiktoken.encoding_for_model``.  Defaults to
+        ``"text-embedding-3-small"`` (cl100k_base).  Use the name of whatever
+        embedding model you are targeting so token counts align exactly.
+
+    Returns
+    -------
+    list[Document]
+        Chunks in document order with fully populated metadata.
+    """
+    encoding = _get_encoding(tiktoken_model)
+
+    if min_section_tokens > 0:
+        sections = _merge_small_sections(
+            sections, min_section_tokens, encoding)
+
+    initial_chunks: list[Document] = []
+
+    for section_index, section in enumerate(sections):
+        if not section.text:
+            continue
+
+        section_tokens = _count_tokens(section.text, encoding)
+
+        base_meta = {
+            "document_id": document_id,
+            "section": section.title,
+            "section_level": section.level,
+            "section_index": section_index,
+            "page_start": section.page_start,
+            "page_end": section.page_end,
+            "num_images": 0,
+        }
+
+        if section_tokens <= chunk_size:
+            initial_chunks.append(Document(
+                page_content=section.text,
+                metadata={**base_meta, "local_chunk_index": 0},
+            ))
+            continue
+
+        paragraphs = _split_paragraphs(section.text)
+        merged = _merge_paragraphs(
+            paragraphs, chunk_size, chunk_overlap, encoding)
+
+        for local_index, chunk_text in enumerate(merged):
+            initial_chunks.append(Document(
+                page_content=chunk_text,
+                metadata={**base_meta, "local_chunk_index": local_index},
+            ))
+
+    # Last-resort fallback for any chunk still over chunk_size (e.g. a single
+    # paragraph that is an enormous table or unbroken figure caption).
+    # from_tiktoken_encoder uses the same tokeniser so the limit is consistent.
+    # strip_whitespace=False keeps chunks as exact substrings of the section
+    # text, which the post-pass below relies on for accurate page lookup.
+    fallback = RecursiveCharacterTextSplitter.from_tiktoken_encoder(
+        model_name=tiktoken_model,
         chunk_size=chunk_size,
         chunk_overlap=chunk_overlap,
         separators=["\n\n", "\n", ". ", " ", ""],
+        strip_whitespace=False,
     )
+    final_chunks = fallback.split_documents(initial_chunks)
 
-    final_chunks = fallback_splitter.split_documents(initial_chunks)
+    # Refine per-chunk page metadata using each section's page_spans. Chunks
+    # are emitted in document order; a per-section running search pointer
+    # disambiguates repeated substrings (e.g. when paragraph-level overlap
+    # makes consecutive chunks share text). Every chunk gets a single ``page``
+    # value: the dominant (most-overlapped) page when it spans a boundary, and
+    # the section's start page as a last-resort fallback if substring lookup
+    # fails.
+    cur_sec_idx: int | None = None
+    search_pos = 0
+    for chunk in final_chunks:
+        sec_idx = chunk.metadata.get("section_index")
+        if sec_idx != cur_sec_idx:
+            cur_sec_idx = sec_idx
+            search_pos = 0
+        if sec_idx is None or sec_idx >= len(sections):
+            continue
+        section = sections[sec_idx]
+        if not section.page_spans:
+            chunk.metadata.setdefault("page", section.page_start)
+            continue
+        text = chunk.page_content
+        pos = section.text.find(text, search_pos)
+        if pos < 0:
+            pos = section.text.find(text)
+        if pos < 0:
+            chunk.metadata.setdefault("page", section.page_start)
+            continue
+        ps, pe = _pages_for_range(
+            section.page_spans, pos, pos + len(text))
+        if ps is not None:
+            chunk.metadata["page_start"] = ps
+            chunk.metadata["page_end"] = pe
+            dom = _dominant_page(
+                section.page_spans, pos, pos + len(text))
+            chunk.metadata["page"] = dom if dom is not None else ps
+        else:
+            chunk.metadata.setdefault("page", section.page_start)
+        search_pos = pos + 1
 
-    for chunk_index, chunk in enumerate(final_chunks):
-        chunk.metadata["chunk_id"] = f"{document_id}_chunk_{chunk_index}"
-        chunk.metadata["chunk_index"] = chunk_index
+    for i, chunk in enumerate(final_chunks):
+        chunk.metadata["chunk_id"] = f"{document_id}_chunk_{i}"
+        chunk.metadata["chunk_index"] = i
 
     return final_chunks

--- a/backend/chunker.py
+++ b/backend/chunker.py
@@ -1,0 +1,158 @@
+import re
+from typing import Iterable
+
+from langchain_core.documents import Document
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+
+SECTION_HEADING_PATTERN = re.compile(
+    r"^\s*(?:"
+    r"(?:\d+(?:\.\d+)*\.?\s+[A-Z][^\n]{2,120})"
+    r"|(?:Abstract|Introduction|Background|Related Work|Method|Methods|Methodology|"
+    r"Experiments|Results|Discussion|Conclusion|References|Appendix)\s*$"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _clean_text(text: str) -> str:
+    text = text or ""
+    text = re.sub(r"-\n(?=\w)", "", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _is_section_heading(line: str) -> bool:
+    line = line.strip()
+    if not line:
+        return False
+    return bool(SECTION_HEADING_PATTERN.match(line))
+
+
+def _split_page_into_sections(text: str) -> list[tuple[str | None, str]]:
+    lines = text.splitlines()
+    sections: list[tuple[str | None, list[str]]] = []
+    current_heading: str | None = None
+    current_lines: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        if _is_section_heading(stripped):
+            if current_lines:
+                sections.append((current_heading, current_lines))
+            current_heading = stripped
+            current_lines = [stripped]
+        else:
+            current_lines.append(line)
+
+    if current_lines:
+        sections.append((current_heading, current_lines))
+
+    return [
+        (heading, "\n".join(section_lines).strip())
+        for heading, section_lines in sections
+        if "\n".join(section_lines).strip()
+    ]
+
+
+def _split_paragraphs(text: str) -> list[str]:
+    paragraphs = re.split(r"\n\s*\n", text)
+    return [p.strip() for p in paragraphs if p.strip()]
+
+
+def _merge_paragraphs(
+    paragraphs: Iterable[str],
+    max_chars: int,
+    overlap_chars: int,
+) -> list[str]:
+    chunks: list[str] = []
+    current = ""
+
+    for paragraph in paragraphs:
+        if not current:
+            current = paragraph
+            continue
+
+        candidate = current + "\n\n" + paragraph
+
+        if len(candidate) <= max_chars:
+            current = candidate
+        else:
+            chunks.append(current)
+
+            if overlap_chars > 0:
+                overlap = current[-overlap_chars:]
+                current = overlap + "\n\n" + paragraph
+            else:
+                current = paragraph
+
+    if current:
+        chunks.append(current)
+
+    return chunks
+
+
+def chunk_pages(
+    pages,
+    document_id: str,
+    chunk_size: int = 1200,
+    chunk_overlap: int = 150,
+) -> list[Document]:
+    """
+    Chunk extracted research-paper pages into LangChain Documents.
+
+    Strategy:
+    1. Preserve document/page metadata.
+    2. Detect likely research-paper section headings.
+    3. Split pages into section-aware blocks.
+    4. Split sections into paragraphs.
+    5. Merge paragraphs into chunks.
+    6. Use RecursiveCharacterTextSplitter only as fallback for oversized chunks.
+    """
+    initial_chunks: list[Document] = []
+
+    for page_number, page in enumerate(pages, start=1):
+        page_text = _clean_text(getattr(page, "texts", "") or "")
+        if not page_text:
+            continue
+
+        sections = _split_page_into_sections(page_text)
+
+        for section_index, (section_title, section_text) in enumerate(sections):
+            paragraphs = _split_paragraphs(section_text)
+            merged_chunks = _merge_paragraphs(
+                paragraphs=paragraphs,
+                max_chars=chunk_size,
+                overlap_chars=chunk_overlap,
+            )
+
+            for local_chunk_index, chunk_text in enumerate(merged_chunks):
+                initial_chunks.append(
+                    Document(
+                        page_content=chunk_text,
+                        metadata={
+                            "document_id": document_id,
+                            "page": page_number,
+                            "section": section_title,
+                            "section_index": section_index,
+                            "local_chunk_index": local_chunk_index,
+                            "num_images": len(getattr(page, "images", [])),
+                        },
+                    )
+                )
+
+    fallback_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+
+    final_chunks = fallback_splitter.split_documents(initial_chunks)
+
+    for chunk_index, chunk in enumerate(final_chunks):
+        chunk.metadata["chunk_id"] = f"{document_id}_chunk_{chunk_index}"
+        chunk.metadata["chunk_index"] = chunk_index
+
+    return final_chunks

--- a/backend/db.py
+++ b/backend/db.py
@@ -230,7 +230,7 @@ def retrieve_documents(
     query: str,
     *,
     doc_ids: list[str] | None = None,
-    k: int = 4,
+    k: int = 10,
     vectordb: VectorDBInterface | None = None,
 ) -> list[Document]:
     """
@@ -240,7 +240,7 @@ def retrieve_documents(
     ----------
     query   : the search string
     doc_ids : optional list of doc_ids to scope the search to specific documents
-    k       : number of chunks to return (default 4)
+    k       : number of chunks to return (default 10)
     vectordb: injectable vectordb instance; falls back to the cached default
 
     Returns

--- a/backend/db.py
+++ b/backend/db.py
@@ -40,8 +40,8 @@ from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from vectorstore import VectorDBInterface, PGVectorDBInstance, ChromaDBInstance
-from text_extractor import extract_text_and_images_from_paper
-from chunker import chunk_pages
+from text_extractor import extract_sections
+from chunker import chunk_sections
 
 
 # ----------------------------------------
@@ -204,17 +204,17 @@ def index_document(
         vectordb = _cached_default_vectordb()
 
     # 1. Extract text & image references from the PDF
-    pages = extract_text_and_images_from_paper(BytesIO(file_bytes))
+    sections = extract_sections(BytesIO(file_bytes))
 
     # 2. Persist raw PDF
     doc_id = vectordb.store_pdf(filename=filename, file_bytes=file_bytes)
 
     # 3. Chunk pages with research-paper-aware chunker
-    chunks = chunk_pages(
-        pages,
+    chunks = chunk_sections(
+        sections,
         document_id=doc_id,
-        chunk_size=int(os.getenv("CHUNK_SIZE", "1200")),
-        chunk_overlap=int(os.getenv("CHUNK_OVERLAP", "150")),
+        chunk_size=int(os.getenv("CHUNK_SIZE", "256")),
+        chunk_overlap=int(os.getenv("CHUNK_OVERLAP", "64")),
     )
 
     # 4. Add fields expected by retrieval / prompt formatting

--- a/backend/db.py
+++ b/backend/db.py
@@ -38,6 +38,7 @@ from psycopg2.extras import RealDictCursor
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_core.embeddings import Embeddings
 
 from vectorstore import VectorDBInterface, PGVectorDBInstance, ChromaDBInstance
 from text_extractor import extract_sections
@@ -120,12 +121,15 @@ def init_pgvector_db():
 # Pluggable component factories
 # ----------------------------------------
 
-def get_default_embedding() -> Any:
+def get_embedding_and_size() -> tuple[Embeddings, int]:
     model_name = os.getenv(
         "EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
     )
-    return HuggingFaceEmbeddings(model_name=model_name)
-
+    match model_name:
+        case "sentence-transformers/all-MiniLM-L6-v2":
+            return HuggingFaceEmbeddings(model_name=model_name), 384
+        case "Qwen/Qwen3-Embedding-4B":
+            return HuggingFaceEmbeddings(model_name=model_name), 2560
 
 # TODO: Replace with a better chunking strategy for research papers
 def get_default_text_splitter() -> Any:
@@ -135,9 +139,9 @@ def get_default_text_splitter() -> Any:
     )
 
 
-def get_default_vectordb(embedding: Optional[Any] = None) -> VectorDBInterface:
+def get_vectordb(embedding: Optional[Embeddings] = None, embedding_size: Optional[int] = None) -> VectorDBInterface:
     if embedding is None:
-        embedding = get_default_embedding()
+        embedding, embedding_size = get_embedding_and_size()
 
     backend = os.getenv("VECTOR_DB", "pgvector").lower()
 
@@ -146,6 +150,7 @@ def get_default_vectordb(embedding: Optional[Any] = None) -> VectorDBInterface:
         db = PGVectorDBInstance(
             embedding_func=embedding,
             collection_name=os.getenv("PGVECTOR_COLLECTION", "chunks"),
+            vector_size=embedding_size
         )
         db.set_connection_string(
             user=DB_USER,
@@ -174,7 +179,7 @@ _default_vectordb: Optional[VectorDBInterface] = None
 def _cached_default_vectordb() -> VectorDBInterface:
     global _default_vectordb
     if _default_vectordb is None:
-        _default_vectordb = get_default_vectordb()
+        _default_vectordb = get_vectordb()
     return _default_vectordb
 
 
@@ -184,11 +189,6 @@ def _cached_default_vectordb() -> VectorDBInterface:
 
 def get_vectordb_dep() -> VectorDBInterface:
     return _cached_default_vectordb()
-
-
-def get_text_splitter_dep() -> Any:
-    return get_default_text_splitter()
-
 
 # ----------------------------------------
 # Core indexing logic
@@ -263,7 +263,6 @@ def get_document_ids(vectordb: VectorDBInterface | None = None) -> list[str]:
 # ----------------------------------------
 # Conversation history
 # ----------------------------------------
-
 
 def store_message(
     session_id: str,

--- a/backend/db.py
+++ b/backend/db.py
@@ -41,6 +41,7 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from vectorstore import VectorDBInterface, PGVectorDBInstance, ChromaDBInstance
 from text_extractor import extract_text_and_images_from_paper
+from chunker import chunk_pages
 
 
 # ----------------------------------------
@@ -198,30 +199,9 @@ def index_document(
     *,
     filename: str = "",
     vectordb: Optional[VectorDBInterface] = None,
-    text_splitter: Any = None,
 ) -> str:
-    """
-    Store a raw PDF and index its text chunks in the vector store.
-
-    Steps
-    -----
-    1. Extract per-page text (and image counts) from the PDF bytes.
-    2. Persist the raw PDF via vectordb.store_pdf() and obtain a doc_id.
-    3. Wrap each page as a LangChain Document with metadata.
-    4. Chunk the documents with the text splitter.
-    5. Index the chunks into the vector store.
-
-    Returns
-    -------
-    str
-        doc_id on success; propagates exceptions on failure.
-    """
-    print("Test")
     if vectordb is None:
         vectordb = _cached_default_vectordb()
-        print("Got VectorDB")
-    if text_splitter is None:
-        text_splitter = get_default_text_splitter()
 
     # 1. Extract text & image references from the PDF
     pages = extract_text_and_images_from_paper(BytesIO(file_bytes))
@@ -229,28 +209,22 @@ def index_document(
     # 2. Persist raw PDF
     doc_id = vectordb.store_pdf(filename=filename, file_bytes=file_bytes)
 
-    # 3. Build LangChain Documents
-    lc_pages = [
-        Document(
-            page_content=page.texts or "",
-            metadata={
-                "num_images": len(page.images),
-                "filename": filename,
-                "doc_id": doc_id,
-                "page_index": i,
-            },
-        )
-        for i, page in enumerate(pages)
-    ]
+    # 3. Chunk pages with research-paper-aware chunker
+    chunks = chunk_pages(
+        pages,
+        document_id=doc_id,
+        chunk_size=int(os.getenv("CHUNK_SIZE", "1200")),
+        chunk_overlap=int(os.getenv("CHUNK_OVERLAP", "150")),
+    )
 
-    # 4. Chunk
-    chunks = text_splitter.split_documents(lc_pages)
+    # 4. Add fields expected by retrieval / prompt formatting
+    for chunk in chunks:
+        chunk.metadata["filename"] = filename
+        chunk.metadata["doc_id"] = doc_id
 
     # 5. Index
     vectordb.index_documents(chunks)
-
     return doc_id
-
 
 def retrieve_documents(
     query: str,

--- a/backend/db.py
+++ b/backend/db.py
@@ -125,6 +125,7 @@ def get_embedding_and_size() -> tuple[Embeddings, int]:
     model_name = os.getenv(
         "EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
     )
+    print("Loading embedding model:", model_name)
     match model_name:
         case "sentence-transformers/all-MiniLM-L6-v2":
             return HuggingFaceEmbeddings(model_name=model_name), 384

--- a/backend/db.py
+++ b/backend/db.py
@@ -84,7 +84,7 @@ def init_pgvector_db():
         # separately; this table is only for raw-file retrieval.
         cur.execute("""
             CREATE TABLE IF NOT EXISTS pdf_documents (
-                doc_id      TEXT PRIMARY KEY,
+                document_id      TEXT PRIMARY KEY,
                 filename    TEXT NOT NULL,
                 pdf         BYTEA NOT NULL,
                 uploaded_at TIMESTAMPTZ DEFAULT now()
@@ -220,7 +220,7 @@ def index_document(
     # 4. Add fields expected by retrieval / prompt formatting
     for chunk in chunks:
         chunk.metadata["filename"] = filename
-        chunk.metadata["doc_id"] = doc_id
+        #chunk.metadata["doc_id"] = doc_id
 
     # 5. Index
     vectordb.index_documents(chunks)

--- a/backend/db.py
+++ b/backend/db.py
@@ -130,6 +130,8 @@ def get_embedding_and_size() -> tuple[Embeddings, int]:
             return HuggingFaceEmbeddings(model_name=model_name), 384
         case "Qwen/Qwen3-Embedding-4B":
             return HuggingFaceEmbeddings(model_name=model_name), 2560
+        case _:
+            raise ValueError(f"Unsupported model name: {model_name}")
 
 # TODO: Replace with a better chunking strategy for research papers
 def get_default_text_splitter() -> Any:

--- a/backend/db_test.py
+++ b/backend/db_test.py
@@ -49,7 +49,6 @@ def test_add_document_indexes_and_retrieves():
             json={
                 "raw_document": payload,
                 "filename": "paper.pdf",
-                "collection": "test-session",
                 "session_id" : "testy"
             },
         )
@@ -92,7 +91,6 @@ def test_search_embedding_returns_relevant_chunks():
             json={
                 "raw_document": payload,
                 "filename": "paper.pdf",
-                "collection": "test-session",
                 "session_id": "testy"
             },
         )
@@ -102,7 +100,7 @@ def test_search_embedding_returns_relevant_chunks():
         r = client.post(
             "/search/embedding",
             json={
-                "list_of_document_ids": [doc_id],
+                "document_ids": [doc_id],
                 "query": "What is attention?",
             },
         )

--- a/backend/db_test.py
+++ b/backend/db_test.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 from langchain_huggingface import HuggingFaceEmbeddings
 
 from main import app  
-from db import get_vectordb_dep, get_text_splitter_dep, get_default_text_splitter
+from db import get_vectordb_dep, get_default_text_splitter
 from vectorstore import ChromaDBInstance
 
 
@@ -40,7 +40,6 @@ def test_add_document_indexes_and_retrieves():
     )
 
     app.dependency_overrides[get_vectordb_dep] = lambda: test_vectordb
-    app.dependency_overrides[get_text_splitter_dep] = get_default_text_splitter
 
     try:
         client = TestClient(app)
@@ -81,7 +80,6 @@ def test_search_embedding_returns_relevant_chunks():
     )
 
     app.dependency_overrides[get_vectordb_dep] = lambda: test_vectordb
-    app.dependency_overrides[get_text_splitter_dep] = get_default_text_splitter
 
     try:
         client = TestClient(app)

--- a/backend/main.py
+++ b/backend/main.py
@@ -76,8 +76,11 @@ class MockEmbedder:
 if os.getenv("LOAD_MODELS", "false").lower() == "true":
     print("Loading models")
     from ml import LLM, Embedder
-    llm = LLM("google/gemma-3-4b-it")
-    embedder = Embedder("Qwen/Qwen3-Embedding-4B")
+    llm_model = os.getenv("LLM_MODEL", "google/gemma-3-4b-it")
+    llm = LLM(llm_model)
+    
+    embedder_model = os.getenv("EMBEDDER_MODEL", "Qwen/Qwen3-Embedding-4B")
+    embedder = Embedder(embedder_model)
 else:
     print("Skipping models loading")
     llm = MockLLM()
@@ -117,7 +120,6 @@ async def health():
 def create_session() -> str:
     """
     Create a new empty session for the user.
-
     Returns:
         session_id: The ID of the newly created session.
     """
@@ -128,7 +130,6 @@ def create_session() -> str:
 def delete_session(session_id: str) -> bool:
     """
     Delete an existing session.
-
     Returns:
         bool: True if deleted successfully.
     """
@@ -139,7 +140,6 @@ def delete_session(session_id: str) -> bool:
 def get_session(session_id: str) -> dict:
     """
     Get session conversation and metadata.
-
     Returns:
         dict: Session conversation and metadata.
     """
@@ -171,8 +171,7 @@ class ConversationEntry(BaseModel):
 
 
 def _append_message(session_id: str, request: CreateOrUpdateConversation, vectordb: VectorDBInterface | None = None) -> str:
-    store_message(session_id=session_id, role=request.role,
-                  message=request.message)
+    store_message(session_id=session_id, role=request.role, message=request.message)
     return request.message
 
 @app.post("/sessions/{session_id}/conversation")
@@ -183,7 +182,6 @@ def create_conversation_for_session(
 ) -> str:
     """
     Start or append to a conversation for a session.
- 
     Returns:
         bool: True if stored successfully.
     """
@@ -192,30 +190,32 @@ def create_conversation_for_session(
 
 @app.put("/sessions/{session_id}/conversation")
 def update_conversation_of_session(
-    session_id: str, 
+    session_id: str,
     request: CreateOrUpdateConversation,
     vectordb=Depends(get_vectordb_dep),
 ) -> str:
     """
     Append a message to an existing session's conversation.
- 
     Returns:
         bool: True if stored successfully.
     """
     _append_message(session_id, request, vectordb)
-    conversation = [{"role":message.role, "content":message.message} for message in get_conversation_for_session(session_id)]
+    conversation = [{"role": message.role, "content": message.message}
+                    for message in get_conversation_for_session(session_id)]
     chunks = retrieve_documents(
         query=request.message,
         doc_ids=request.doc_ids,
         vectordb=vectordb,
     )
 
-    response = llm.generate(conversation, chunks)
-    response_request = CreateOrUpdateConversation(
-        message=response,
-        role="assistant",
-        doc_ids=[])
-    _append_message(session_id, response_request, vectordb)
+    try:
+        response = llm.generate(conversation, chunks)
+    except Exception as e:
+        print(f"LLM generation failed: {e}")
+        response = "Something went wrong while generating a response. Please try asking your question again."
+
+    _append_message(session_id, CreateOrUpdateConversation(
+        message=response, role="assistant", doc_ids=[]))
     return response
 
 
@@ -225,7 +225,6 @@ def get_conversation_for_session(
 ) -> list[ConversationEntry]:
     """
     Retrieve the full message history for a session in chronological order.
- 
     Returns:
         List of messages with role, content, and timestamp.
     """
@@ -245,12 +244,10 @@ def get_conversation_for_session(
 def get_conversation_of_session(session_id: str) -> dict:
     """
     Retrieve the full conversation for a session, including the latest response.
-
     Returns:
         dict: The complete conversation history.
     """
     raise NotImplementedError()
-
 
 # ----------------------------------------
 # Document management

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,7 +15,6 @@ from db import (
     index_document,
     retrieve_documents,
     get_vectordb_dep,
-    get_text_splitter_dep,
     VectorDBInterface,
     store_message,
     fetch_conversation,
@@ -79,12 +78,13 @@ if os.getenv("LOAD_MODELS", "false").lower() == "true":
     llm_model = os.getenv("LLM_MODEL", "google/gemma-3-4b-it")
     llm = LLM(llm_model)
     
-    embedder_model = os.getenv("EMBEDDER_MODEL", "Qwen/Qwen3-Embedding-4B")
-    embedder = Embedder(embedder_model)
+    # NOTE: As for now, embedder is not initialized here
+    #embedder_model = os.getenv("EMBEDDER_MODEL", "Qwen/Qwen3-Embedding-4B")
+    #embedder = Embedder(embedder_model)
 else:
     print("Skipping models loading")
     llm = MockLLM()
-    embedder = MockEmbedder()
+    #embedder = MockEmbedder()
 
 # ----------------------------------------
 # Health / root
@@ -277,7 +277,6 @@ class AddDocumentRequest(BaseModel):
 def add_document(
     request: AddDocumentRequest,
     vectordb=Depends(get_vectordb_dep),
-    text_splitter=Depends(get_text_splitter_dep),
 ) -> str:
     """
     Decode, store, and index a base64-encoded PDF.

--- a/backend/main.py
+++ b/backend/main.py
@@ -345,7 +345,7 @@ def delete_document(document_id: str) -> bool:
 # ----------------------------------------
 
 class SearchKeywordRequest(BaseModel):
-    list_of_document_ids: list[str]
+    document_ids: list[str]
     query: str
 
 
@@ -361,7 +361,7 @@ def search_keyword(request: SearchKeywordRequest) -> list:
 
 
 class SearchEmbeddingRequest(BaseModel):
-    list_of_document_ids: list[str]
+    document_ids: list[str]
     query: str
 
 
@@ -372,7 +372,7 @@ def search_embedding(
 ) -> list:
     chunks = retrieve_documents(
         query=request.query,
-        doc_ids=request.list_of_document_ids,
+        doc_ids=request.document_ids,
         vectordb=vectordb,
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,8 +61,9 @@ class MockLLM:
         for i, doc in enumerate(documents):
             filename = doc.metadata.get("filename", "unknown file")
             page = doc.metadata.get("page_index", "?")
+            section = doc.metadata.get("section", "?")
             snippet = doc.page_content[:200].replace("\n", " ")
-            lines.append(f"[{i}] {filename} p.{page}: {snippet}...")
+            lines.append(f"[{i}] {filename} p.{page}: section: {section} {snippet}...")
         return f'User msg: {user_msg}\n\n\n' + "\n\n\n".join(lines)
 
 class MockEmbedder:
@@ -297,8 +298,7 @@ def add_document(
         return index_document(
             file_bytes,
             filename=request.filename,
-            vectordb=vectordb,
-            text_splitter=text_splitter,
+            vectordb=vectordb
         )
     except Exception as e:
         print("Error", e)

--- a/backend/main.py
+++ b/backend/main.py
@@ -73,16 +73,16 @@ class MockEmbedder:
 # Load models 
 # ----------------------------------------
 if os.getenv("LOAD_MODELS", "false").lower() == "true":
-    print("Loading models")
     from ml import LLM, Embedder
     llm_model = os.getenv("LLM_MODEL", "google/gemma-3-4b-it")
+    print("Loading model:", llm_model)
     llm = LLM(llm_model)
     
     # NOTE: As for now, embedder is not initialized here
     #embedder_model = os.getenv("EMBEDDER_MODEL", "Qwen/Qwen3-Embedding-4B")
     #embedder = Embedder(embedder_model)
 else:
-    print("Skipping models loading")
+    print("Using mock model")
     llm = MockLLM()
     #embedder = MockEmbedder()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -60,10 +60,10 @@ class MockLLM:
         lines = []
         for i, doc in enumerate(documents):
             filename = doc.metadata.get("filename", "unknown file")
-            page = doc.metadata.get("page_index", "?")
+            page = doc.metadata.get("page", "?")
             section = doc.metadata.get("section", "?")
             snippet = doc.page_content[:200].replace("\n", " ")
-            lines.append(f"[{i}] {filename} p.{page}: section: {section} {snippet}...")
+            lines.append(f"[{i}] {filename} [p.{page}] [section: {section}] \n\n {snippet}...")
         return f'User msg: {user_msg}\n\n\n' + "\n\n\n".join(lines)
 
 class MockEmbedder:

--- a/backend/ml.py
+++ b/backend/ml.py
@@ -1,3 +1,4 @@
+import json
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM, Gemma3ForConditionalGeneration, AutoProcessor
 from sentence_transformers import SentenceTransformer
@@ -80,10 +81,25 @@ class LLM:
             page_str = "p. ?"
         return f"[{i} document] {filename} — Section: {section} ({page_str})"
 
+    def _format_doc_header_for_humans(self, doc: Document) -> str:
+        meta = doc.metadata or {}
+        filename = meta.get("filename") or "unknown"
+        section = meta.get("section") or "—"
+        page = meta.get("page")
+        ps = meta.get("page_start")
+        pe = meta.get("page_end")
+        if page is not None:
+            page_str = f"p. {page}"
+        elif ps is not None and pe is not None:
+            page_str = f"p. {ps}" if ps == pe else f"pp. {ps}-{pe}"
+        else:
+            page_str = "p. ?"
+        return f"<span style='color: gray;'>[{filename} — Section: {section} ({page_str})]</span>"
+
     def generate(self,
                  messages: list[dict],
                  documents: list[Document],
-                 max_new_tokens: int = 200,
+                 max_new_tokens: int = 500,
                  temperature: float = 0.7,
                  top_p: float = 0.9,
                  ) -> str:
@@ -128,6 +144,7 @@ class LLM:
 
                 inputs = self.format_prompt(messages, documents)
 
+
                 input_len = inputs["input_ids"].shape[-1]
 
                 with torch.inference_mode():
@@ -139,7 +156,8 @@ class LLM:
                     generation = generation[0][input_len:]
                 decoded = self.processor.decode(
                     generation, skip_special_tokens=True)
-                return decoded
+                print("DEBUG: Raw model output\n", decoded)
+                return self.replace_model_references(decoded, documents)
             # ------------------------------------------------------------
             # ------------------------------------------------------------
             # ------------------------------------------------------------
@@ -195,7 +213,7 @@ class LLM:
 
                 if len(documents) == 0:
                     conversation[-1]["content"][0]["text"] += f"No relevant documents were found.\n"
-
+                print("DEBUG: Conversation with document headers:\n", json.dumps(conversation, indent=2))
                 return self.processor.apply_chat_template(
                     conversation,
                     add_generation_prompt=True,
@@ -209,6 +227,18 @@ class LLM:
             # ------------------------------------------------------------
             case _:
                 raise ValueError(f"Unsupported model name: {self.model_name}")
+
+
+    def replace_model_references(self, text: str, chunks:list[Document]) -> str:
+        """
+        Replace the model generated "<{n}>" references in the text with the corresponding document headers.
+
+        """
+        for i, doc in enumerate(chunks):
+            header = self._format_doc_header_for_humans(doc)
+            text = text.replace(f"<{{{i}}}>", header)
+        return text
+
 
 
 class Embedder:

--- a/backend/ml.py
+++ b/backend/ml.py
@@ -254,10 +254,14 @@ class Embedder:
 
 
 if __name__ == "__main__":
-    llm = LLM("Qwen/Qwen2.5-0.5B-Instruct")
+    qwen_local = "Qwen/Qwen2.5-0.5B-Instruct"
+    huggy = "HuggingFaceTB/SmolLM2-360M-Instruct"
+    llm = LLM(huggy)
     messages = [
         {"role": "user", "content": "Explain what attention is in a transformer model."}
     ]
+    print("prompt: ")
+    llm.format_prompt(messages, [])
     print("response: ")
     print(llm.generate(messages, []))
 
@@ -272,6 +276,5 @@ if __name__ == "__main__":
     # print(embeddings[0][:10])
     # embeddings = embedding_model.encode(texts, is_query=False)
     # print(embeddings[0][:10])
-
     while True:
         pass

--- a/backend/ml.py
+++ b/backend/ml.py
@@ -3,6 +3,7 @@ from transformers import AutoTokenizer, AutoModelForCausalLM, Gemma3ForCondition
 from sentence_transformers import SentenceTransformer
 from prompts import MAIN_ASSISTANT_PROMPT
 from transformers import BitsAndBytesConfig
+from langchain_core.documents import Document
 import os
 
 
@@ -40,9 +41,30 @@ class LLM:
             case _:
                 raise ValueError(f"Unsupported model name: {self.model_name}")
 
+    @staticmethod
+    def _format_doc_header(i: int, doc: Document) -> str:
+        """Build a citation header from a retrieved chunk's metadata.
+
+        Uses ``page`` when present (set by the chunker for every chunk).
+        Falls back to a ``page_start``/``page_end`` range, then to "?".
+        """
+        meta = doc.metadata or {}
+        filename = meta.get("filename") or "unknown"
+        section = meta.get("section") or "—"
+        page = meta.get("page")
+        ps = meta.get("page_start")
+        pe = meta.get("page_end")
+        if page is not None:
+            page_str = f"p. {page}"
+        elif ps is not None and pe is not None:
+            page_str = f"p. {ps}" if ps == pe else f"pp. {ps}-{pe}"
+        else:
+            page_str = "p. ?"
+        return f"[{i} document] {filename} — Section: {section} ({page_str})"
+
     def generate(self,
                  messages: list[dict],
-                 documents: list[str],
+                 documents: list[Document],
                  max_new_tokens: int = 200,
                  temperature: float = 0.7,
                  top_p: float = 0.9,
@@ -106,7 +128,7 @@ class LLM:
             case _:
                 raise ValueError(f"Unsupported model name: {self.model_name}")
 
-    def format_prompt(self, conversation: list[dict], documents: list[str]):
+    def format_prompt(self, conversation: list[dict], documents: list[Document]):
         match self.model_name:
 
             # ------------------------------------------------------------
@@ -119,7 +141,8 @@ class LLM:
                 conversation[-1]["content"] += "\n\nRetrieved documents:"
 
                 for i, doc in enumerate(documents):
-                    conversation[-1]["content"] += f"\n[{i} document]\n {doc}\n"
+                    header = self._format_doc_header(i, doc)
+                    conversation[-1]["content"] += f"\n{header}\n{doc.page_content}\n"
 
                 if len(documents) == 0:
                     conversation[-1]["content"] += f"No relevant documents were found.\n"
@@ -147,7 +170,8 @@ class LLM:
                 conversation[-1]["content"][0]["text"] += "\n\nRetrieved documents:"
 
                 for i, doc in enumerate(documents):
-                    conversation[-1]["content"][0]["text"] += f"\n[{i} document]\n {doc}\n"
+                    header = self._format_doc_header(i, doc)
+                    conversation[-1]["content"][0]["text"] += f"\n{header}\n{doc.page_content}\n"
 
                 if len(documents) == 0:
                     conversation[-1]["content"][0]["text"] += f"No relevant documents were found.\n"

--- a/backend/ml.py
+++ b/backend/ml.py
@@ -162,6 +162,7 @@ class LLM:
                     tokenize=True,
                     add_generation_prompt=True,
                 )
+                print("DEBUG: Prompt\n", final_prompt)
                 return final_prompt
 
             # ------------------------------------------------------------

--- a/backend/ml.py
+++ b/backend/ml.py
@@ -38,6 +38,16 @@ class LLM:
                 ).eval()
                 self.processor = AutoProcessor.from_pretrained(
                     model_name_or_path)
+
+
+            case "HuggingFaceTB/SmolLM2-360M-Instruct":
+                self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+                if load_model:
+                    self.model = AutoModelForCausalLM.from_pretrained(
+                        model_name,
+                        torch_dtype=torch.float32,
+                        device_map="cpu"
+                    )
             case _:
                 raise ValueError(f"Unsupported model name: {self.model_name}")
 
@@ -74,7 +84,7 @@ class LLM:
             # ------------------------------------------------------------
             # -----ministral/Ministral-3b-instruct------------------------
             # ------------------------------------------------------------
-            case "ministral/Ministral-3b-instruct":
+            case "HuggingFaceTB/SmolLM2-360M-Instruct" | "ministral/Ministral-3b-instruct":
                 # print(f"Conversation: {messages}")
 
                 prompt = self.tokenizer.apply_chat_template(
@@ -134,7 +144,7 @@ class LLM:
             # ------------------------------------------------------------
             # ------ministral/Ministral-3b-instruct-----------------------
             # ------------------------------------------------------------
-            case  "ministral/Ministral-3b-instruct":
+            case "HuggingFaceTB/SmolLM2-360M-Instruct" | "ministral/Ministral-3b-instruct":
                 conversation = [
                     {"role": "system", "content": MAIN_ASSISTANT_PROMPT}] + conversation
 
@@ -194,15 +204,20 @@ class LLM:
 class Embedder:
     def __init__(self, model_name: str):
         self.model_name = model_name
-
         match self.model_name:
-
             # this model was chosen mostly at random.
             # It has a hight score on the MTEB benchmark, and is relatively small, which should make it faster to run.
             case "Qwen/Qwen3-Embedding-4B":
                 self.model = SentenceTransformer(
                     "Qwen/Qwen3-Embedding-4B",
                     device="cuda" if torch.cuda.is_available() else "cpu"
+                )
+                
+
+            case "sentence-transformers/all-MiniLM-L6-v2":
+                self.model = SentenceTransformer(
+                    "sentence-transformers/all-MiniLM-L6-v2",
+                    device="cpu"
                 )
 
             case _:
@@ -214,27 +229,29 @@ class Embedder:
             is_query = False
 
         match self.model_name:
-
             case "Qwen/Qwen3-Embedding-4B":
                 return self.model.encode(
                     input,
                     prompt_name="query" if is_query else "document",
                     device="cuda" if torch.cuda.is_available() else "cpu"
                 ).tolist()
+                
+            case "sentence-transformers/all-MiniLM-L6-v2":
+                return self.model.encode(input).tolist()
 
             case _:
                 raise ValueError(f"Unsupported model name: {self.model_name}")
 
 
 if __name__ == "__main__":
-    llm = LLM("ministral/Ministral-3b-instruct")
+    llm = LLM("HuggingFaceTB/SmolLM2-360M-Instruct")
     messages = [
         {"role": "user", "content": "Explain what attention is in a transformer model."}
     ]
     print("response: ")
-    print(llm.generate(messages))
+    print(llm.generate(messages, []))
 
-    embedding_model = Embedder("Qwen/Qwen3-Embedding-4B")
+    embedding_model = Embedder("sentence-transformers/all-MiniLM-L6-v2")
 
     texts = [
         "Some text",

--- a/backend/ml.py
+++ b/backend/ml.py
@@ -12,6 +12,14 @@ class LLM:
         self.model_name = model_name
         self.root = os.getenv("MODEL_ROOT", "/files")
         match model_name:
+            case "Qwen/Qwen2.5-0.5B-Instruct":
+                self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+                if load_model:
+                    self.model = AutoModelForCausalLM.from_pretrained(
+                        model_name,
+                        torch_dtype=torch.float32,  # CPU-safe
+                        device_map="cpu"
+                    )
             case "ministral/Ministral-3b-instruct":
                 model_name_or_path = f"{self.root}/Ministral-3b-instruct" if os.path.exists(
                     f"{self.root}/Ministral-3b-instruct") else "ministral/Ministral-3b-instruct"
@@ -84,7 +92,7 @@ class LLM:
             # ------------------------------------------------------------
             # -----ministral/Ministral-3b-instruct------------------------
             # ------------------------------------------------------------
-            case "HuggingFaceTB/SmolLM2-360M-Instruct" | "ministral/Ministral-3b-instruct":
+            case "ministral/Ministral-3b-instruct" | "HuggingFaceTB/SmolLM2-360M-Instruct" | "Qwen/Qwen2.5-0.5B-Instruct":
                 # print(f"Conversation: {messages}")
 
                 prompt = self.tokenizer.apply_chat_template(
@@ -141,10 +149,11 @@ class LLM:
     def format_prompt(self, conversation: list[dict], documents: list[Document]):
         match self.model_name:
 
+
             # ------------------------------------------------------------
-            # ------ministral/Ministral-3b-instruct-----------------------
+            # -----Models suitable for local testing
             # ------------------------------------------------------------
-            case "HuggingFaceTB/SmolLM2-360M-Instruct" | "ministral/Ministral-3b-instruct":
+            case "ministral/Ministral-3b-instruct" | "HuggingFaceTB/SmolLM2-360M-Instruct" | "Qwen/Qwen2.5-0.5B-Instruct":
                 conversation = [
                     {"role": "system", "content": MAIN_ASSISTANT_PROMPT}] + conversation
 
@@ -245,24 +254,24 @@ class Embedder:
 
 
 if __name__ == "__main__":
-    llm = LLM("HuggingFaceTB/SmolLM2-360M-Instruct")
+    llm = LLM("Qwen/Qwen2.5-0.5B-Instruct")
     messages = [
         {"role": "user", "content": "Explain what attention is in a transformer model."}
     ]
     print("response: ")
     print(llm.generate(messages, []))
 
-    embedding_model = Embedder("sentence-transformers/all-MiniLM-L6-v2")
+    # embedding_model = Embedder("sentence-transformers/all-MiniLM-L6-v2")
 
-    texts = [
-        "Some text",
-        "Some other text"
-    ]
+    # texts = [
+    #     "Attention is cool",
+    #     "Some other text"
+    # ]
 
-    embeddings = embedding_model.encode(texts, is_query=True)
-    print(embeddings[0][:10])
-    embeddings = embedding_model.encode(texts, is_query=False)
-    print(embeddings[0][:10])
+    # embeddings = embedding_model.encode(texts, is_query=True)
+    # print(embeddings[0][:10])
+    # embeddings = embedding_model.encode(texts, is_query=False)
+    # print(embeddings[0][:10])
 
     while True:
         pass

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -21,36 +21,45 @@ Guidelines:
 - Do not use outside knowledge.
 - Do not claim certainty when the evidence is weak.
 - Keep answers grounded in the retrieved text.
+- Never infer missing scientific details that are not explicitly stated in the retrieved chunks.
 - When possible, mention important experimental conditions, assumptions, datasets, or limitations.
 - Avoid unnecessary repetition.
 - Answer in complete sentences.
 
-Citations:
-- Every factual claim drawn from a chunk MUST be followed by YOUR inline citation (NOT the one in the paper!)
-- Cite using the format: (ACTUAL_FILENAME, Section: ACTUAL_SECTION, p. ACTUAL_PAGE) where each field is replaced with the real value from the chunk header.
-- Example: (bleu_evaluation.pdf, Section: 3. Results, p. 5)
-- The filename MUST be copied exactly as it appears at the start of the chunk header (before the —). It is never optional.
-- If the section is —, omit it: (filename, p. page).
-- If the chunk's page is a range, preserve it: (filename, p. 3-4).
-- When one sentence combines facts from multiple chunks, list all citations separated by ;.
-- Only cite chunks that actually appear in the retrieved documents — never invent filenames, sections, or page numbers.
-- If a statement cannot be supported by any retrieved chunk, do not attach a citation and make the lack of support clear.
-- ANY citation markers that appear inside the chunk text itself — such as "(Smith et al., 2020)", "[12]", "[1,2]", footnote numbers, or any bracketed/parenthesised reference — are citations the original authors made to OTHER works not available to you. NEVER reproduce these in your response. Treat them as if they are invisible.
-- When a chunk attributes something to another work (e.g. "Smith et al. showed X"), drop the attribution entirely and just state the fact with your own citation to the chunk: "X was demonstrated (filename, Section: ..., p. ...)."
-- "Bouamor et al. 2014", "Espinosa et al. 2010" and any similar author-year patterns found inside chunk text are NOT your citations. Never reproduce them. They are invisible to you.
+Citation rules:
+- Every factual statement, claim, conclusion, numeric value, comparison, or experimental observation derived from the provided chunks MUST include at least one chunk reference.
+- References must use the format <{n}> where n is the chunk number from the chunk header.
+- Example:
+  - <{0}> for "[0 document]"
+  - <{1}> for "[1 document]"
+- If a statement is supported by multiple chunks, include all relevant chunk references.
+- References should appear immediately after the supported statement or paragraph.
+- If a statement cannot be directly supported by the provided chunks, explicitly state that the information is not available in the retrieved context.
+- Never provide unsupported claims without saying they are unsupported.
+- Never mention or reference documents that were not explicitly provided in the retrieved chunks.
+- Only reference the specific chunk(s) that directly support the statement being made.
+- Do not reference chunks that were not used for the specific claim.
+- Do not repeatedly cite the same chunk unless the response genuinely depends on multiple distinct facts from that chunk.
+- Prefer distributing references across relevant chunks when multiple chunks support the answer.
+- Avoid ending every sentence or paragraph with the same reference repeatedly.
+- If consecutive statements are supported by the same chunk, group them together into a single coherent passage followed by one reference.
+
+Handling references inside chunk text:
+- ANY citation markers that appear inside the chunk text itself — such as "(Smith et al., 2020)", "[12]", "[1,2]", footnote numbers, or any bracketed/parenthesised reference — are citations the original authors made to OTHER works not available to you.
+- NEVER reproduce these references in your response.
+- Treat all such references as invisible.
+- When a chunk attributes something to another work (e.g. "Smith et al. showed X"), remove the attribution and state only the supported claim using your own chunk reference.
 
 Direct quotes:
 - When the chunk text contains a particularly precise or important claim, you may quote it directly.
-- Format direct quotes with quotation marks followed immediately by the citation: "exact text from chunk" (filename, Section: section, p. page).
-- Keep direct quotes short (one or two sentences maximum). Paraphrase everything else.
-- Never quote citation markers that appear inside the chunk (e.g. do not quote "[1]" or "(Smith et al., 2020)").
+- Keep direct quotes short (one or two sentences maximum).
+- Never quote citation markers that appear inside the chunk text.
 
 Response style:
 - Be direct and scientific.
 - Use short paragraphs.
 - Use bullet points when useful.
 - If relevant, explain reasoning briefly using the provided evidence.
-- End every paragraph that contains factual claims with its reference in terms of filename, section and page number.
 - Never reproduce the raw chunk headers (e.g. "[2 document] file.pdf — Section: ...") in your response.
 - Do NOT use any markdown formatting: no bold (**text**), no italic (*text*), no headers (##), no bullet asterisks. Use plain text only.
 - Plain hyphens (-) are acceptable for bullet points if needed.

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -5,7 +5,7 @@ You will receive:
 
 1. Previous conversation.
 2. A user question.
-3. A collection of document chunks retrieved from scientific papers.Each chunk is preceded by a header of the form: [N document] <filename> — Section: <section title> (p. <page>) The page field may appear as a range (e.g. pp. 3-4) when a chunk straddles a page boundary. A section shown as — means the chunk has no enclosing heading.
+3. A collection of document chunks retrieved from scientific papers. Each chunk is preceded by a header of the form: [N document] filename — Section: section title (p. page). The page field may appear as a range (e.g. pp. 3-4) when a chunk straddles a page boundary. A section shown as — means the chunk has no enclosing heading.
 
 Your task is to:
 - Answer the question clearly, accurately, and concisely.
@@ -27,20 +27,31 @@ Guidelines:
 
 Citations:
 - Every factual claim drawn from a chunk MUST be followed by an inline citation.
-- Cite using the format: (<filename>, Section: <section>, p. <page>).
+- Cite using the format: (ACTUAL_FILENAME, Section: ACTUAL_SECTION, p. ACTUAL_PAGE) where each field is replaced with the real value from the chunk header.
+- Example: (bleu_evaluation.pdf, Section: 3. Results, p. 5)
 - The filename MUST be copied exactly as it appears at the start of the chunk header (before the —). It is never optional.
-- If the section is —, omit it: (<filename>, p. <page>).
-- If the chunk's page is a range, preserve it: (<filename>, p. 3-4).
-- When one sentence combines facts from multiple chunks, list all citations separated by ;, e.g. (<filename>, Section: Methods, p. 3; <filename>, Section: Results, p. 7).
+- If the section is —, omit it: (filename, p. page).
+- If the chunk's page is a range, preserve it: (filename, p. 3-4).
+- When one sentence combines facts from multiple chunks, list all citations separated by ;.
 - Only cite chunks that actually appear in the retrieved documents — never invent filenames, sections, or page numbers.
 - If a statement cannot be supported by any retrieved chunk, do not attach a citation and make the lack of support clear.
-- References inside the chunk text (e.g. "(Smith et al., 2020)", "[12]", footnote markers) are citations the original paper makes to other works that are NOT available to you. Do NOT reproduce them in parentheses as if they were your citations.
-- If a chunk says "X was shown by Smith et al. (2020)", you may keep that attribution in prose but cite the chunk header: "Prior work showed X (actual-filename.pdf, Section: Introduction, p. 2)."
+- ANY citation markers that appear inside the chunk text itself — such as "(Smith et al., 2020)", "[12]", "[1,2]", footnote numbers, or any bracketed/parenthesised reference — are citations the original authors made to OTHER works not available to you. NEVER reproduce these in your response. Treat them as if they are invisible.
+- When a chunk attributes something to another work (e.g. "Smith et al. showed X"), drop the attribution entirely and just state the fact with your own citation to the chunk: "X was demonstrated (filename, Section: ..., p. ...)."
+- "Bouamor et al. 2014", "Espinosa et al. 2010" and any similar author-year patterns found inside chunk text are NOT your citations. Never reproduce them. They are invisible to you.
+
+Direct quotes:
+- When the chunk text contains a particularly precise or important claim, you may quote it directly.
+- Format direct quotes with quotation marks followed immediately by the citation: "exact text from chunk" (filename, Section: section, p. page).
+- Keep direct quotes short (one or two sentences maximum). Paraphrase everything else.
+- Never quote citation markers that appear inside the chunk (e.g. do not quote "[1]" or "(Smith et al., 2020)").
 
 Response style:
 - Be direct and scientific.
 - Use short paragraphs.
 - Use bullet points when useful.
 - If relevant, explain reasoning briefly using the provided evidence.
-- End every paragraph that contains factual claims with its citation(s) so the user can verify each statement.
+- End every paragraph that contains factual claims with its reference in terms of filename, section and page number.
+- Never reproduce the raw chunk headers (e.g. "[2 document] file.pdf — Section: ...") in your response.
+- Do NOT use any markdown formatting: no bold (**text**), no italic (*text*), no headers (##), no bullet asterisks. Use plain text only.
+- Plain hyphens (-) are acceptable for bullet points if needed.
 """

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -5,7 +5,7 @@ You will receive:
 
 1. Previous conversation.
 2. A user question.
-3. A collection of document chunks retrieved from scientific papers.
+3. A collection of document chunks retrieved from scientific papers.Each chunk is preceded by a header of the form: [N document] <filename> — Section: <section title> (p. <page>) The page field may appear as a range (e.g. pp. 3-4) when a chunk straddles a page boundary. A section shown as — means the chunk has no enclosing heading.
 
 Your task is to:
 - Answer the question clearly, accurately, and concisely.
@@ -25,10 +25,22 @@ Guidelines:
 - Avoid unnecessary repetition.
 - Answer in complete sentences.
 
+Citations:
+- Every factual claim drawn from a chunk MUST be followed by an inline citation.
+- Cite using the format: (<filename>, Section: <section>, p. <page>).
+- The filename MUST be copied exactly as it appears at the start of the chunk header (before the —). It is never optional.
+- If the section is —, omit it: (<filename>, p. <page>).
+- If the chunk's page is a range, preserve it: (<filename>, p. 3-4).
+- When one sentence combines facts from multiple chunks, list all citations separated by ;, e.g. (<filename>, Section: Methods, p. 3; <filename>, Section: Results, p. 7).
+- Only cite chunks that actually appear in the retrieved documents — never invent filenames, sections, or page numbers.
+- If a statement cannot be supported by any retrieved chunk, do not attach a citation and make the lack of support clear.
+- References inside the chunk text (e.g. "(Smith et al., 2020)", "[12]", footnote markers) are citations the original paper makes to other works that are NOT available to you. Do NOT reproduce them in parentheses as if they were your citations.
+- If a chunk says "X was shown by Smith et al. (2020)", you may keep that attribution in prose but cite the chunk header: "Prior work showed X (actual-filename.pdf, Section: Introduction, p. 2)."
+
 Response style:
 - Be direct and scientific.
 - Use short paragraphs.
 - Use bullet points when useful.
 - If relevant, explain reasoning briefly using the provided evidence.
+- End every paragraph that contains factual claims with its citation(s) so the user can verify each statement.
 """
-

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -26,7 +26,7 @@ Guidelines:
 - Answer in complete sentences.
 
 Citations:
-- Every factual claim drawn from a chunk MUST be followed by an inline citation.
+- Every factual claim drawn from a chunk MUST be followed by YOUR inline citation (NOT the one in the paper!)
 - Cite using the format: (ACTUAL_FILENAME, Section: ACTUAL_SECTION, p. ACTUAL_PAGE) where each field is replaced with the real value from the chunk header.
 - Example: (bleu_evaluation.pdf, Section: 3. Results, p. 5)
 - The filename MUST be copied exactly as it appears at the start of the chunk header (before the —). It is never optional.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,8 @@ sentence-transformers
 # PDF parsing
 pypdf
 pypdf[image]
+pymupdf-layout==1.27.2.3
+pymupdf4llm==1.27.2.3
 
 # Tokeniser used by RecursiveCharacterTextSplitter.from_tiktoken_encoder
 tiktoken

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,8 @@ psycopg2-binary==2.9.9
 langchain-community
 langchain-core
 langchain-text-splitters
-langchain_postgres
+langchain_postgres==0.0.17
+langchain-chroma==1.1.0
 pgvector
 chromadb
 

--- a/backend/text_extractor.py
+++ b/backend/text_extractor.py
@@ -1,38 +1,174 @@
-"""
-text_extractor.py — Extract per-page text and images from PDF files.
-"""
+from __future__ import annotations
 
-from pypdf import PdfReader
+import re
+from dataclasses import dataclass, field
+from io import IOBase
+from pathlib import Path
 
-
-class Page:
-    """Holds the extracted text and raw image bytes for a single PDF page."""
-
-    def __init__(self, text: str, images: list[bytes]):
-        self.texts = text
-        self.images = images
+import pymupdf
+import pymupdf4llm
 
 
-def extract_text_and_images_from_paper(file_path) -> list[Page]:
+# ---------------------------------------------------------------------------
+# Public data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Section:
+    """One logical section extracted from a Markdown-converted PDF."""
+    title: str | None   # None for content before the first heading
+    level: int          # 1 for #, 2 for ##, 0 for preamble content
+    text: str           # body text, heading line excluded
+    page_start: int     # 1-indexed
+    page_end: int       # 1-indexed; inclusive
+    # Per-character page mapping: contiguous list of (start, end_exclusive, page)
+    # covering [0, len(text)) when text is non-empty. Same-page consecutive runs
+    # are coalesced. Used by the chunker to derive per-chunk page numbers when
+    # a section spans multiple pages.
+    page_spans: list[tuple[int, int, int]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Internal Markdown parser
+# ---------------------------------------------------------------------------
+
+# ATX heading: optional leading whitespace, 1–6 #, one space, title text.
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
+
+
+def _trim_blank_lines(lines_with_pages: list[tuple[str, int]]) -> list[tuple[str, int]]:
+    """Drop leading/trailing entries whose line is empty or whitespace-only."""
+    start = 0
+    end = len(lines_with_pages)
+    while start < end and not lines_with_pages[start][0].strip():
+        start += 1
+    while end > start and not lines_with_pages[end - 1][0].strip():
+        end -= 1
+    return lines_with_pages[start:end]
+
+
+def _build_text_and_spans(
+    lines_with_pages: list[tuple[str, int]],
+) -> tuple[str, list[tuple[int, int, int]]]:
+    """Join ``(line, page)`` pairs on ``"\\n"`` and return ``(text, page_spans)``.
+
+    ``page_spans`` contiguously covers ``[0, len(text))`` with consecutive
+    same-page runs coalesced; the inter-line ``"\\n"`` separator is absorbed
+    into the preceding span so spans abut exactly.
     """
-    Extract text and images from each page of a PDF.
+    if not lines_with_pages:
+        return "", []
+
+    line_spans: list[tuple[int, int, int]] = []
+    parts: list[str] = []
+    offset = 0
+    for i, (line, page) in enumerate(lines_with_pages):
+        if i > 0:
+            parts.append("\n")
+            offset += 1
+        start = offset
+        parts.append(line)
+        offset += len(line)
+        line_spans.append((start, offset, page))
+
+    spans: list[tuple[int, int, int]] = []
+    for s, e, p in line_spans:
+        if spans and spans[-1][2] == p:
+            spans[-1] = (spans[-1][0], e, p)
+        else:
+            if spans:
+                prev = spans[-1]
+                spans[-1] = (prev[0], s, prev[2])
+            spans.append((s, e, p))
+
+    return "".join(parts), spans
+
+
+def _parse_page_chunks(page_chunks: list[dict]) -> list[Section]:
+    """Parse pymupdf4llm ``page_chunks=True`` output into :class:`Section`s."""
+    sections: list[Section] = []
+    current_title: str | None = None
+    current_level: int = 0
+    current_lines: list[tuple[str, int]] = []
+    section_page_start: int = 1
+    last_page: int = 1
+
+    def _flush(end_page: int) -> None:
+        trimmed = _trim_blank_lines(current_lines)
+        text, spans = _build_text_and_spans(trimmed)
+        if text or current_title is not None:
+            sections.append(Section(
+                title=current_title,
+                level=current_level,
+                text=text,
+                page_start=section_page_start,
+                page_end=end_page,
+                page_spans=spans,
+            ))
+
+    for idx, entry in enumerate(page_chunks):
+        meta = entry.get("metadata", {}) or {}
+        page_num = meta.get("page") or (idx + 1)
+        last_page = page_num
+        if not sections and current_title is None and not current_lines:
+            section_page_start = page_num
+
+        for line in (entry.get("text", "") or "").splitlines():
+            m = _HEADING_RE.match(line)
+            if m:
+                _flush(page_num)
+                current_title = m.group(2).strip()
+                current_level = len(m.group(1))
+                current_lines = []
+                section_page_start = page_num
+            else:
+                current_lines.append((line, page_num))
+
+    _flush(last_page)
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def extract_sections(source: str | Path | bytes | bytearray | IOBase) -> list[Section]:
+    """
+    Extract logical sections from a PDF by converting it to Markdown first.
+
+    Uses ``pymupdf4llm.to_markdown(..., page_chunks=True)`` so page numbers
+    come from PyMuPDF directly (per-page metadata) instead of being inferred
+    from in-text separators.
 
     Parameters
     ----------
-    file_path : str | pathlib.Path | file-like object
-        Path to a PDF file, or any file-like object accepted by PdfReader
-        (e.g. ``io.BytesIO``).
+    source:
+        Either a filesystem path to a PDF, or in-memory PDF bytes / a
+        binary file-like object (e.g. ``BytesIO``).
 
     Returns
     -------
-    list[Page]
-        One ``Page`` per PDF page, each containing the page's text and a list
-        of raw image bytes.
+    list[Section]
+        Sections in document order.  The first entry may have ``title=None``
+        for any content appearing before the first heading.  Each section
+        carries a ``page_spans`` mapping from character offsets within
+        ``text`` to source page numbers.
     """
-    reader = PdfReader(file_path)
-    output = []
-    for page in reader.pages:
-        text = page.extract_text() or ""
-        images = [img.data for img in page.images]
-        output.append(Page(text, images))
-    return output
+    if isinstance(source, (str, Path)):
+        doc = pymupdf.open(str(source))
+    elif isinstance(source, (bytes, bytearray)):
+        doc = pymupdf.open(stream=bytes(source), filetype="pdf")
+    elif isinstance(source, IOBase):
+        source.seek(0)
+        doc = pymupdf.open(stream=source.read(), filetype="pdf")
+    else:
+        raise TypeError(
+            f"extract_sections: unsupported source type {type(source).__name__}"
+        )
+
+    try:
+        page_chunks = pymupdf4llm.to_markdown(doc, page_chunks=True)
+    finally:
+        doc.close()
+
+    return _parse_page_chunks(page_chunks)

--- a/backend/vectorstore.py
+++ b/backend/vectorstore.py
@@ -137,7 +137,7 @@ class PGVectorDBInstance(VectorDBInterface):
         with psycopg2.connect(self._raw_conn_string) as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "INSERT INTO pdf_documents (document_id, filename, pdf) VALUES (%s, %s, %s) ON CONFLICT (doc_id) DO NOTHING",
+                    "INSERT INTO pdf_documents (document_id, filename, pdf) VALUES (%s, %s, %s) ON CONFLICT (document_id) DO NOTHING",
                     (doc_id, filename, psycopg2.Binary(file_bytes))
                 )
         return doc_id
@@ -252,7 +252,7 @@ class ChromaDBInstance(VectorDBInterface):
         matches = [f for f in os.listdir(
             self._pdf_store_dir) if f.startswith(doc_id)]
         if not matches:
-            raise KeyError(f"No document found for doc_id={doc_id}")
+            raise KeyError(f"No document found for document_id={doc_id}")
         filepath = os.path.join(self._pdf_store_dir, matches[0])
         _, original_filename = matches[0].split("@", 1)
         with open(filepath, "rb") as f:

--- a/backend/vectorstore.py
+++ b/backend/vectorstore.py
@@ -1,4 +1,3 @@
-# vectorstore.py
 import os
 import json
 import uuid

--- a/backend/vectorstore.py
+++ b/backend/vectorstore.py
@@ -106,7 +106,7 @@ class PGVectorDBInstance(VectorDBInterface):
             with conn.cursor() as cur:
                 cur.execute("""
                     CREATE TABLE IF NOT EXISTS pdf_documents (
-                        doc_id      TEXT PRIMARY KEY,
+                        document_id      TEXT PRIMARY KEY,
                         filename    TEXT NOT NULL,
                         pdf         BYTEA NOT NULL,
                         uploaded_at TIMESTAMPTZ DEFAULT now()
@@ -137,7 +137,7 @@ class PGVectorDBInstance(VectorDBInterface):
         with psycopg2.connect(self._raw_conn_string) as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "INSERT INTO pdf_documents (doc_id, filename, pdf) VALUES (%s, %s, %s) ON CONFLICT (doc_id) DO NOTHING",
+                    "INSERT INTO pdf_documents (document_id, filename, pdf) VALUES (%s, %s, %s) ON CONFLICT (doc_id) DO NOTHING",
                     (doc_id, filename, psycopg2.Binary(file_bytes))
                 )
         return doc_id
@@ -147,12 +147,13 @@ class PGVectorDBInstance(VectorDBInterface):
         with psycopg2.connect(self._raw_conn_string) as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT filename, pdf FROM pdf_documents WHERE doc_id = %s",
+                    "SELECT filename, pdf FROM pdf_documents WHERE document_id = %s",
                     (doc_id,)
                 )
                 row = cur.fetchone()
                 if row is None:
-                    raise KeyError(f"No document found for doc_id={doc_id}")
+                    raise KeyError(
+                        f"No document found for document_id={doc_id}")
                 filename, pdf_bytes = row
                 return filename, bytes(pdf_bytes)
 
@@ -202,7 +203,7 @@ class PGVectorDBInstance(VectorDBInterface):
         with psycopg2.connect(self._raw_conn_string) as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT doc_id, filename FROM pdf_documents ORDER BY uploaded_at ASC"
+                    "SELECT document_id, filename FROM pdf_documents ORDER BY uploaded_at ASC"
                 )
                 return {doc_id: filename for doc_id, filename in cur.fetchall()}
 
@@ -225,7 +226,7 @@ class PGVectorDBInstance(VectorDBInterface):
         vs = self.get_vectorstore()
         search_kwargs = {"k": k}
         if doc_ids:
-            search_kwargs["filter"] = {"doc_id": {"$in": doc_ids}}
+            search_kwargs["filter"] = {"document_id": {"$in": doc_ids}}
         return vs.as_retriever(search_kwargs=search_kwargs)
 
 
@@ -330,5 +331,5 @@ class ChromaDBInstance(VectorDBInterface):
         vs = self.get_vectorstore()
         search_kwargs = {"k": k}
         if doc_ids:
-            search_kwargs["filter"] = {"doc_id": {"$in": doc_ids}}
+            search_kwargs["filter"] = {"document_id": {"$in": doc_ids}}
         return vs.as_retriever(search_kwargs=search_kwargs)

--- a/backend/vectorstore.py
+++ b/backend/vectorstore.py
@@ -7,6 +7,8 @@ from langchain_community.vectorstores import VectorStore
 import hashlib
 from langchain_postgres import PGEngine, PGVectorStore
 from langchain_chroma import Chroma
+from langchain_core.embeddings import Embeddings
+
 
 def document_hash(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
@@ -65,7 +67,7 @@ class VectorDBInterface(ABC):
 
 
 class PGVectorDBInstance(VectorDBInterface):
-    def __init__(self, embedding_func, collection_name, vector_size: int = 384):
+    def __init__(self, embedding_func: Embeddings, collection_name: str, vector_size: int):
         self.connection_string = None
         self._raw_conn_string = None
         self.embedding = embedding_func
@@ -231,7 +233,7 @@ class PGVectorDBInstance(VectorDBInterface):
 
 
 class ChromaDBInstance(VectorDBInterface):
-    def __init__(self, embedding_func, persist_directory: str = "./chroma_db"):
+    def __init__(self, embedding_func: Embeddings, persist_directory: str = "./chroma_db"):
         print("Init ChromaDB")
         self.embedding = embedding_func
         self.persist_directory = persist_directory

--- a/backend/vectorstore.py
+++ b/backend/vectorstore.py
@@ -1,15 +1,12 @@
 import os
 import json
-import uuid
 import psycopg2
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from langchain_community.vectorstores import Chroma
 from langchain_community.vectorstores import VectorStore
 import hashlib
 from langchain_postgres import PGEngine, PGVectorStore
-from psycopg.errors import DuplicateTable
-
+from langchain_chroma import Chroma
 
 def document_hash(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()

--- a/backend/vectorstore.py
+++ b/backend/vectorstore.py
@@ -227,7 +227,7 @@ class PGVectorDBInstance(VectorDBInterface):
     def as_retriever(self, doc_ids: list[str] | None = None, k: int = 4):
         vs = self.get_vectorstore()
         search_kwargs = {"k": k}
-        if doc_ids is not None:
+        if doc_ids:
             search_kwargs["filter"] = {"doc_id": {"$in": doc_ids}}
         return vs.as_retriever(search_kwargs=search_kwargs)
 
@@ -332,6 +332,6 @@ class ChromaDBInstance(VectorDBInterface):
     def as_retriever(self, doc_ids: list[str] | None = None, k: int = 4):
         vs = self.get_vectorstore()
         search_kwargs = {"k": k}
-        if doc_ids is not None:
+        if doc_ids:
             search_kwargs["filter"] = {"doc_id": {"$in": doc_ids}}
         return vs.as_retriever(search_kwargs=search_kwargs)

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -10,25 +10,34 @@ USER_AVATAR = None
 BOT_AVATAR = None
 HOST_IP = os.getenv('HOST_IP', None)
 API_BASE_URL = f"http://{HOST_IP}:8500" if HOST_IP is not None else "http://127.0.0.1:8500"
-STREAM_RESPONSE = os.getenv("STREAM_RESPONSE", "true").lower() == "true"
+STREAM_RESPONSE = os.getenv("STREAM_RESPONSE", "false").lower() == "true"
 
-def handle_answer(st, answer):
-    if STREAM_RESPONSE:
-    # Simulate streaming
-        def stream_response():
-            for word in answer.split(" "):
-                yield word + " "
-                time.sleep(0.05)
-        displayed = st.write_stream(stream_response())
+
+def handle_answer(st, answer, stream_response=True):
+    if stream_response:
+        placeholder = st.empty()
+        rendered_text = ""
+
+        for word in answer.split():
+            rendered_text += word + " "
+            placeholder.markdown(
+                rendered_text,
+                unsafe_allow_html=True,
+            )
+            time.sleep(0.05)
     else:
-        st.markdown(answer)
+        st.markdown(
+            answer,
+            unsafe_allow_html=True,
+        )
+
 
 def prepare_document_payload(file_bytes: bytes, filename: str, session_id: str) -> dict:
     encoded = base64.b64encode(file_bytes).decode("utf-8")
     return {
         "raw_document": encoded,
         "filename": filename,
-        "session_id": session_id
+        "session_id": session_id,
     }
 
 
@@ -54,7 +63,9 @@ def fetch_session_conversation(session_id: str) -> list:
             ]
         else:
             st.toast(
-                f"Could not load session history ({response.status_code})", icon="⚠️")
+                f"Could not load session history ({response.status_code})",
+                icon="⚠️",
+            )
             return []
     except requests.exceptions.RequestException as e:
         st.toast(f"Could not reach backend: {e}", icon="⚠️")
@@ -69,7 +80,9 @@ def fetch_all_documents() -> dict:
             return response.json()
         else:
             st.toast(
-                f"Could not load documents ({response.status_code})", icon="⚠️")
+                f"Could not load documents ({response.status_code})",
+                icon="⚠️",
+            )
             return {}
     except requests.exceptions.RequestException as e:
         st.toast(f"Could not reach backend: {e}", icon="⚠️")
@@ -85,6 +98,7 @@ def fetch_all_sessions() -> list[str]:
     except requests.exceptions.RequestException:
         return []
 
+
 def send_query(query: str, session_id: str, selected_docs: list) -> str:
     """Send a user query and return the assistant's response text."""
     payload = prepare_query_payload(query, session_id, selected_docs)
@@ -94,8 +108,7 @@ def send_query(query: str, session_id: str, selected_docs: list) -> str:
             json=payload,
         )
         if response.status_code == 200:
-            return response.json()  # backend now returns a plain string
-            #return response.json().get("response", "_(No response)_")
+            return response.json()
         else:
             return f"_(Backend error {response.status_code})_"
     except requests.exceptions.RequestException as e:
@@ -106,7 +119,7 @@ def switch_session(session_id: str):
     """Switch the active session and load its conversation from the backend."""
     st.session_state.session_id = session_id
     st.session_state.messages = fetch_session_conversation(session_id)
-    # Restore uploaded docs for the session if tracked
+
     session_meta = st.session_state.all_sessions.get(session_id, {})
     st.session_state.uploaded_docs = session_meta.get("uploaded_docs", {})
     st.session_state.uploader_key += 1
@@ -118,8 +131,9 @@ def save_current_session_meta():
     if sid not in st.session_state.all_sessions:
         st.session_state.all_sessions[sid] = {
             "label": f"Session {sid[:6]}",
-            "created_at": time.strftime("%H:%M %d/%m/%y")
+            "created_at": time.strftime("%H:%M %d/%m/%y"),
         }
+
 
 # UI Config
 st.set_page_config(
@@ -131,12 +145,16 @@ st.set_page_config(
 # ── Session state bootstrap ────────────────────────────────────────────────
 if "session_id" not in st.session_state:
     st.session_state.session_id = str(uuid4())
+
 if "messages" not in st.session_state:
     st.session_state.messages = []
+
 if "all_docs" not in st.session_state:
     st.session_state.all_docs = fetch_all_documents()
+
 if "uploader_key" not in st.session_state:
     st.session_state.uploader_key = 0
+
 if "all_sessions" not in st.session_state:
     st.session_state.all_sessions = {}
     for sid in fetch_all_sessions():
@@ -146,7 +164,6 @@ if "all_sessions" not in st.session_state:
             "uploaded_docs": {},
         }
 
-# Make sure the current session is always registered
 save_current_session_meta()
 
 session_id = st.session_state.session_id
@@ -154,12 +171,11 @@ short_id = session_id[:6]
 
 # ── Sidebar ────────────────────────────────────────────────────────────────
 with st.sidebar:
-    st.markdown("### 📚 Research Paper RAG")
+    st.markdown("### 📚 Research Paper RAG", unsafe_allow_html=True)
     st.caption("Group 23")
     st.divider()
 
-    # ── Active session ─────────────────────────────────────────────────────
-    st.markdown("**Session**")
+    st.markdown("**Session**", unsafe_allow_html=True)
     st.code(short_id, language="text")
 
     if st.button("🆕 New session", use_container_width=True):
@@ -172,8 +188,7 @@ with st.sidebar:
 
     st.divider()
 
-    # ── Past sessions list ─────────────────────────────────────────────────
-    st.markdown("**Sessions**")
+    st.markdown("**Sessions**", unsafe_allow_html=True)
 
     all_sessions = st.session_state.all_sessions
     if len(all_sessions) <= 1:
@@ -191,6 +206,7 @@ with st.sidebar:
             """,
             unsafe_allow_html=True,
         )
+
         with st.container(height=180, key="session_list_container"):
             for sid, meta in reversed(list(all_sessions.items())):
                 is_active = sid == session_id
@@ -211,8 +227,8 @@ with st.sidebar:
 
     st.divider()
 
-    # ── Document upload ────────────────────────────────────────────────────
-    st.markdown("**Documents**")
+    st.markdown("**Documents**", unsafe_allow_html=True)
+
     uploaded_files = st.file_uploader(
         "Upload a document",
         type=["pdf", "txt"],
@@ -224,15 +240,19 @@ with st.sidebar:
     for uploaded_file in uploaded_files:
         file_bytes = uploaded_file.read()
         doc_payload = prepare_document_payload(
-            file_bytes, uploaded_file.name, short_id
+            file_bytes,
+            uploaded_file.name,
+            short_id,
         )
+
         with st.spinner(f"Uploading {uploaded_file.name}..."):
             response = requests.post(
                 f"{API_BASE_URL}/documents",
                 json=doc_payload,
             )
+
         if response.status_code == 200:
-            st.session_state.all_docs = fetch_all_documents()  # refresh globally
+            st.session_state.all_docs = fetch_all_documents()
             st.toast(f"{uploaded_file.name} uploaded!", icon="✅")
         else:
             st.toast(f"❌ Upload failed ({response.status_code})", icon="❌")
@@ -241,7 +261,6 @@ with st.sidebar:
         st.session_state.uploader_key += 1
         st.rerun()
 
-    # ── Document list (scrollable + selectable) ────────────────────────────
     if st.session_state.all_docs:
         with st.container(height=200):
             selected_doc_ids = []
@@ -249,6 +268,7 @@ with st.sidebar:
                 checked = st.checkbox(f"📄 {filename}", key=f"doc_{doc_id}")
                 if checked:
                     selected_doc_ids.append(doc_id)
+
         st.session_state.selected_docs = selected_doc_ids
     else:
         st.caption("No documents uploaded yet.")
@@ -259,49 +279,57 @@ with st.sidebar:
 st.title("Research Paper RAG 📚")
 st.caption("Ask questions about your uploaded research papers.")
 
-
 st.session_state.messages = fetch_session_conversation(session_id)
 
 if not st.session_state.messages:
     with st.chat_message("assistant", avatar=BOT_AVATAR):
         st.markdown(
-            "Hi! Upload a paper from the sidebar and ask me anything about it."
+            "Hi! Upload a paper from the sidebar and ask me anything about it.",
+            unsafe_allow_html=True,
         )
 
 for msg in st.session_state.messages:
     avatar = USER_AVATAR if msg["role"] == "user" else BOT_AVATAR
     with st.chat_message(msg["role"], avatar=avatar):
-        st.markdown(msg["content"])
+        st.markdown(
+            msg["content"],
+            unsafe_allow_html=True,
+        )
 
 selected_docs = st.session_state.get("selected_docs", [])
 uploaded_docs = st.session_state.get("all_docs", {})
 
 if uploaded_docs and not selected_docs:
     st.warning(
-        "No documents selected — check at least one in the sidebar for the model to use.", icon="📄")
+        "No documents selected — check at least one in the sidebar for the model to use.",
+        icon="📄",
+    )
 
 query = st.chat_input("Ask a question about your documents...")
 
 if query:
-    # 1. Show and persist the user message
-    st.session_state.messages.append({"role": "user", "content": query})
-    with st.chat_message("user", avatar=USER_AVATAR):
-        st.markdown(query)
+    st.session_state.messages.append(
+        {"role": "user", "content": query}
+    )
 
-    # 2. Get and show the assistant response
+    with st.chat_message("user", avatar=USER_AVATAR):
+        st.markdown(
+            query,
+            unsafe_allow_html=True,
+        )
+
     selected_docs = st.session_state.get("selected_docs", [])
+
     with st.chat_message("assistant", avatar=BOT_AVATAR):
         with st.spinner("Thinking..."):
             answer = send_query(query, session_id, selected_docs)
-        handle_answer(st, answer)
-        # #st.markdown(answer)
-        
-        # # Simulate streaming
-        # def stream_response():
-        #     for word in answer.split(" "):
-        #         yield word + " "
-        #         time.sleep(0.05)
-        # displayed = st.write_stream(stream_response())
 
-    # 3. Persist the assistant response
-    st.session_state.messages.append({"role": "assistant", "content": answer})
+        handle_answer(
+            st,
+            answer,
+            stream_response=STREAM_RESPONSE,
+        )
+
+    st.session_state.messages.append(
+        {"role": "assistant", "content": answer}
+    )

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -10,7 +10,18 @@ USER_AVATAR = None
 BOT_AVATAR = None
 HOST_IP = os.getenv('HOST_IP', None)
 API_BASE_URL = f"http://{HOST_IP}:8500" if HOST_IP is not None else "http://127.0.0.1:8500"
+STREAM_RESPONSE = os.getenv("STREAM_RESPONSE", "true").lower() == "true"
 
+def handle_answer(st, answer):
+    if STREAM_RESPONSE:
+    # Simulate streaming
+        def stream_response():
+            for word in answer.split(" "):
+                yield word + " "
+                time.sleep(0.05)
+        displayed = st.write_stream(stream_response())
+    else:
+        st.markdown(answer)
 
 def prepare_document_payload(file_bytes: bytes, filename: str, session_id: str) -> dict:
     encoded = base64.b64encode(file_bytes).decode("utf-8")
@@ -282,7 +293,15 @@ if query:
     with st.chat_message("assistant", avatar=BOT_AVATAR):
         with st.spinner("Thinking..."):
             answer = send_query(query, session_id, selected_docs)
-        st.markdown(answer)
+        handle_answer(st, answer)
+        # #st.markdown(answer)
+        
+        # # Simulate streaming
+        # def stream_response():
+        #     for word in answer.split(" "):
+        #         yield word + " "
+        #         time.sleep(0.05)
+        # displayed = st.write_stream(stream_response())
 
     # 3. Persist the assistant response
     st.session_state.messages.append({"role": "assistant", "content": answer})

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -26,6 +26,8 @@ def handle_answer(st, answer, stream_response=True):
             )
             time.sleep(0.05)
     else:
+
+        st.rerun()
         st.markdown(
             answer,
             unsafe_allow_html=True,
@@ -175,18 +177,18 @@ with st.sidebar:
     st.caption("Group 23")
     st.divider()
 
-    st.markdown("**Session**", unsafe_allow_html=True)
-    st.code(short_id, language="text")
+    # st.markdown("**Session**", unsafe_allow_html=True)
+    # st.code(short_id, language="text")
 
-    if st.button("🆕 New session", use_container_width=True):
-        new_id = str(uuid4())
-        st.session_state.session_id = new_id
-        st.session_state.messages = []
-        st.session_state.uploader_key += 1
-        save_current_session_meta()
-        st.rerun()
+    # # if st.button("🆕 New session", use_container_width=True):
+    # #     new_id = str(uuid4())
+    # #     st.session_state.session_id = new_id
+    # #     st.session_state.messages = []
+    # #     st.session_state.uploader_key += 1
+    # #     save_current_session_meta()
+    # #     st.rerun()
 
-    st.divider()
+    # st.divider()
 
     st.markdown("**Sessions**", unsafe_allow_html=True)
 
@@ -207,10 +209,25 @@ with st.sidebar:
             unsafe_allow_html=True,
         )
 
+        if st.button("🆕 New session", use_container_width=True):
+            new_id = str(uuid4())
+            st.session_state.session_id = new_id
+            st.session_state.messages = []
+            st.session_state.uploader_key += 1
+            save_current_session_meta()
+            st.rerun()
         with st.container(height=180, key="session_list_container"):
             for sid, meta in reversed(list(all_sessions.items())):
+                # print(f"Session {sid}: {meta}")
+                conversation = fetch_session_conversation(sid)
+                if len(conversation) == 0:
+                    first_user_msg = "No messages yet."
+                elif conversation[0]["role"] == "user":
+                    first_user_msg = conversation[0]["content"]
+                else:
+                    first_user_msg = conversation[1]["content"] if len(conversation) > 1 else "No messages yet."
                 is_active = sid == session_id
-                label = f"{'🟢 ' if is_active else ''}{meta['label']}"
+                label = f"{'🟢 ' if is_active else ''}{first_user_msg}"
                 help_text = f"Created {meta['created_at']}"
                 btn_type = "primary" if is_active else "secondary"
 


### PR DESCRIPTION
Integrated @trofej chunker into updated project. After verifying it works as it should and perhaps even adding more enhancement to satisfy user stories, can be merged. 

Features added:
* Text extractor was upgraded. Transforms PDFs to Markdown and exploits Markdown structure (headings indicated with `#`) to obtain "sections"
* Chunker chunks "sections" rather than pages. Section titles and page numbers are now perserved in chunk metadata.
* Addressed the following bugs 
    * #30 
    * #31 
* A dumb LLM was added for local testing. The LLM does not seem to read the document at all but works on CPU. 

* Frontend: Add fake streaming responses; to give the Illusion that the LLM is typing out its answer. In reality, if we see an answer, the full answer has already arrived. Might make it more user friendly. 