### PR TITLE
Changes to the way that the LLM generates referencs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -48,6 +48,8 @@ requests server-side, not from a browser origin.
 ## Testing Locally
 ```python
 VECTOR_DB=chroma LOAD_MODELS=true LLM_MODEL=HuggingFaceTB/SmolLM2-360M-Instruct EMBEDDER_MODEL=sentence-transformers/all-MiniLM-L6-v2 python3 main.py
+or 
+VECTOR_DB=chroma LOAD_MODELS=true python3 main.py
 ```
 * Will use ChromaDB instead of PGVector
 * If LOAD_MODELS=true, will use the specified models. The ones specified here are much weaker than the production one and can be run from CPU

--- a/backend/ml.py
+++ b/backend/ml.py
@@ -1,4 +1,5 @@
 import json
+import random
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM, Gemma3ForConditionalGeneration, AutoProcessor
 from sentence_transformers import SentenceTransformer
@@ -6,7 +7,7 @@ from prompts import MAIN_ASSISTANT_PROMPT
 from transformers import BitsAndBytesConfig
 from langchain_core.documents import Document
 import os
-
+import re 
 
 class LLM:
     def __init__(self, model_name: str, load_model=True):
@@ -99,7 +100,7 @@ class LLM:
     def generate(self,
                  messages: list[dict],
                  documents: list[Document],
-                 max_new_tokens: int = 500,
+                 max_new_tokens: int = 1500,
                  temperature: float = 0.7,
                  top_p: float = 0.9,
                  ) -> str:
@@ -198,6 +199,10 @@ class LLM:
             case "google/gemma-3-4b-it":
                 # import json
                 # print(json.dumps(conversation, indent=2))
+
+                # remove all but last user message
+                conversation = conversation[-1:]
+
                 for i, msg in enumerate(conversation):
                     conversation[i]["content"] = [
                         {"type": "text", "text": msg["content"]}]
@@ -214,6 +219,18 @@ class LLM:
                 if len(documents) == 0:
                     conversation[-1]["content"][0]["text"] += f"No relevant documents were found.\n"
                 print("DEBUG: Conversation with document headers:\n", json.dumps(conversation, indent=2))
+                
+                # remove html references from previous messages
+                # example reference "<span style='color: gray;'>[filename — Section: section (p. ?)]</span>"
+                for i in range(len(conversation)-1):
+                    regex = r"<span style='color: gray;'>\[(.*?)\]</span>"
+                    # conversation[i]["content"][0]["text"] = re.sub(regex, r"", conversation[i]["content"][0]["text"])
+                    conversation[i]["content"][0]["text"] = re.sub(
+                        regex,
+                        lambda match: f"<{{{random.randint(1,10)}}}>",
+                        conversation[i]["content"][0]["text"]
+                    )
+                print("DEBUG: Conversation after removing HTML references:\n", json.dumps(conversation, indent=2))
                 return self.processor.apply_chat_template(
                     conversation,
                     add_generation_prompt=True,
@@ -237,6 +254,10 @@ class LLM:
         for i, doc in enumerate(chunks):
             header = self._format_doc_header_for_humans(doc)
             text = text.replace(f"<{{{i}}}>", header)
+
+        # remove invalid references that were not replaced (e.g. <{11}>, <{12}>, etc.)            
+        text = re.sub(r"<\{\d+\}>", "", text)
+
         return text
 
 


### PR DESCRIPTION
I tried to improve the references generated by the LLM, but I was unable to fix them reliably in most cases. The model was still able to generate invalid references (e.g. incorrect formatting or references to non-existent chunks).

As a workaround, I implemented a hacky fix that allows the model to see only the latest user message instead of the full conversation history. I noticed that the LLM’s reference-generation performance degrades significantly as the conversation grows longer.

Overall, I do not believe that the model is intellectually capable of consistently providing correct references (or formatting them), at least without fine-tuning.

Also added:
* Functionality to remove invalid references. For example, if the model receives 10 chunks but generates a reference such as `"<{12}>"`, the invalid reference is automatically removed.
* HTML reference removal from previous messages. This is currently inactive because the model now only sees the latest user message rather than the entire conversation history.
